### PR TITLE
Updated h3==3.7.7 to h3==4.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,25 +48,25 @@ $ pip install urbanpy
 
 Then use `import urbanpy` in your python scripts to use the library.
 
-If you plan to use the [OSRM Server](http://project-osrm.org/) route or distance matrix calculation functionalities* you must have Docker installed in your system, refer to Docker [Installation](https://www.docker.com/products/docker-desktop). For Windows users, make sure to run the following command in powershell to avoid execution errors.
+If you plan to use the [OSRM Server](http://project-osrm.org/) route or distance matrix calculation functionalities\* you must have Docker installed in your system, refer to Docker [Installation](https://www.docker.com/products/docker-desktop). For Windows users, make sure to run the following command in powershell to avoid execution errors.
 
 ```powershell
     Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser
 ```
 
-
 ### Additional Dependecies Notes
 
 - It is important to note that for travel time computation, if needed, a method is implements the Open Source Routing Machine (OSRM). This method pulls, extracts and adds graph weights to the downloaded network and runs the routing server. Make sure to have docker installed for the library to work correctly. Also, verify in the docker settings that containers can use the necessary cpu cores and ram memory (it depends in the country size).
 
-- Urbanpy provides a simple approximation with nearest neighbor search using a BallTree and haversine distance, but the difference between real travel time and the approximation may vary from city to city.  
+- Urbanpy provides a simple approximation with nearest neighbor search using a BallTree and haversine distance, but the difference between real travel time and the approximation may vary from city to city.
 
 - Additionally, the use of spatial libraries like osmnx, geopandas and h3 require certain extra packages. Specifically, for rtree (spatial indexing to allow spatial joins) libspatialindex is required. OSMnx and Geopandas requiere GDAL as well. If not handled by installing geopandas's dependencies, installing fiona, pyproj and shapely should satisfy the requirements. Another way to ensure all dependencies are met, installing osmnx via conda should suffice. H3 requires cc, make, and cmake in your $PATH when installing, otherwise installation will not be successful. Please refer to [h3's documentation](https://github.com/uber/h3) for a more
-detailed guide on installation options and requirements.
+  detailed guide on installation options and requirements.
 
 # Examples
 
 UrbanPy lets you download and visualize city boundaries extremely easy:
+
 ```python
 import urbanpy as up
 
@@ -77,7 +77,7 @@ boundaries.plot()
 Since `boundaries` is a GeoDataFrame it can be easily plotted with the method `.plot()`. You can also generate hexagons to fill the city boundaries in a oneliner.
 
 ```python
-hexs, hexs_centroids = up.geom.gen_hexagons(resolution=9, city=boundaries)
+hexes = up.geom.gen_hexagons(resolution=9, city=boundaries)
 ```
 
 Also check our [example notebooks](https://nbviewer.org/github/EL-BID/urbanpy/tree/master/notebooks/), and if you have examples or visualizations of your own, we encourage you to share contribute.
@@ -114,7 +114,7 @@ UrbanPy's original authors are Claudio Ortega ([socials](https://www.linkedin.co
 [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expected to
 uphold this code.**
 
-*Current support is tested on Linux Ubuntu 18.04 & Mac OS Catalina, coming soon we will test and support Windows 10.
+\*Current support is tested on Linux Ubuntu 18.04 & Mac OS Catalina, coming soon we will test and support Windows 10.
 
 ## Citation
 
@@ -141,6 +141,7 @@ If you use this library or find the documentation useful for your research, plea
 </a>
 
 ## Use Cases
+
 [Urbanpy applied to the education sector in Brasil](https://github.com/EL-BID/IADB-education-1)
 This repo is for code, documentation, and discussion for work associated with a skills-based volunteering project in collaboration with the IADB and urbanpy.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ fonttools==4.53.1
 frictionless==5.17.0
 geopandas==1.0.1
 googlemaps==4.10.0
-h3==3.7.7
+h3==4.1.2
 hdx-python-api==6.3.2
 hdx-python-country==3.7.7
 hdx-python-utilities==3.7.3

--- a/urbanpy/geom/geom.py
+++ b/urbanpy/geom/geom.py
@@ -343,7 +343,7 @@ def resolution_downsampling(
     gdf_coarse = gdf.copy()
     coarse_hex_col = "hex_{}".format(coarse_resolution)
     gdf_coarse[coarse_hex_col] = gdf_coarse[hex_col].apply(
-        lambda x: h3.h3_to_parent(x, coarse_resolution)
+        lambda x: h3.cell_to_parent(x, res=coarse_resolution)
     )
     dfc = gdf_coarse.groupby([coarse_hex_col]).agg(agg).reset_index()
     gdfc_geometry = dfc[coarse_hex_col].apply(geo_boundary_to_polygon)

--- a/urbanpy/geom/geom.py
+++ b/urbanpy/geom/geom.py
@@ -1,10 +1,11 @@
 import pandas as pd
 import geopandas as gpd
 import osmnx as ox
-from h3 import h3
+import h3
 from rich.progress import track
 from urbanpy.utils import geo_boundary_to_polygon
 from typing import Sequence, Union
+import shapely
 
 __all__ = [
     "merge_geom_downloads",
@@ -167,11 +168,12 @@ def gen_hexagons(resolution: int, city: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
 
     total = len(city_poly)  # For rich library to how much progress is needed
     for _, geo in track(city_poly.iterrows(), total=total):
-        hexagons = h3.polyfill(
-            geo["geometry"].__geo_interface__, res=resolution, geo_json_conformant=True
-        )
+        hexagons = h3.geo_to_cells(geo["geometry"], res=resolution)
         for hexagon in hexagons:
-            h3_polygons.append(geo_boundary_to_polygon(hexagon))
+            lat_lng_points = h3.cell_to_boundary(hexagon)
+            lng_lat_points = [(lng, lat) for lat, lng in lat_lng_points]
+
+            h3_polygons.append(shapely.Polygon(lng_lat_points))
             h3_indexes.append(hexagon)
 
     # Create hexagon dataframe

--- a/urbanpy/utils/utils.py
+++ b/urbanpy/utils/utils.py
@@ -5,7 +5,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from geopandas import GeoDataFrame, GeoSeries
-from h3 import h3
+import h3
 from pandas import DataFrame
 from shapely.geometry import MultiPolygon, Polygon
 from shapely.validation import make_valid

--- a/urbanpy/utils/utils.py
+++ b/urbanpy/utils/utils.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 from geopandas import GeoDataFrame, GeoSeries
 import h3
+import shapely
 from pandas import DataFrame
 from shapely.geometry import MultiPolygon, Polygon
 from shapely.validation import make_valid
@@ -166,9 +167,9 @@ def geo_boundary_to_polygon(x):
         Polygon representing H3 hexagon area
 
     """
-    return Polygon(
-        [bound[::-1] for bound in h3.h3_to_geo_boundary(x)]
-    )  #  format as x,y (lon, lat)
+    lat_lng_points = h3.cell_to_boundary(x)
+    lng_lat_points = [(lng, lat) for lat, lng in lat_lng_points]
+    return shapely.Polygon(lng_lat_points)  #  format as x,y (lon, lat)
 
 
 def create_duration_labels(durations):


### PR DESCRIPTION
This pull request is to update the polyfill of the geometries to hexagons using the latest H3 library.
I tested the example in the README.md and the behavior is still the expected.

A few minor changes:
- I updated the `requirements.txt` so it now installs version `h3==4.1.2`.
- Some scripts (`urbanpy/geom/geom.py` and `urbanpy/utils/utils.py`) were using old `h3` imports: `from h3 import h3`.
    - I changed those to just `import h3`.

- The example in the README.md was wrong:
    - `up.geom.gen_hexagons(res, city)` is supposed to return a `geopandas.GeoDataFrame` with the hexagons and the geometries. The example was doing something like `hexs, hex_centroids = up.geom.gen_hexagons(res, city)`, which is not how the function is used.