### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@
 # 4. https://github.com/grst/python-ci-versioneer
 
 name: Test and deploy
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/EL-BID/urbanpy/security/code-scanning/1](https://github.com/EL-BID/urbanpy/security/code-scanning/1)

The best way to fix this issue is to add a `permissions` block to the workflow. You can either add it at the root of the workflow (so it applies to all jobs that do not set their own permissions), or preferably, specify more narrowly-tailored permissions for jobs that require them, while using minimal necessary permissions elsewhere. For workflows that build documentation, run tests, and only require source code checkout, `contents: read` is typically sufficient. For jobs that create releases, you may need `contents: write` and `issues: write` or `pull-requests: write` if releases involve interacting with these resources.

For this fix, add the following minimal block at the root (line after `name: Test and deploy`), which ensures all jobs have `contents: read` unless overridden. If some jobs (e.g., `release`, `deploy`) need elevated permissions to create releases or push artifacts, you can further customize those jobs to add a job-specific block.

**Edit:**
- File: `.github/workflows/main.yml`
- Add permissions block after `name: Test and deploy` (line 15)
- Minimal block is `permissions:\n  contents: read`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
