### PR TITLE
Performance Improvements

### DIFF
--- a/urbanpy/accessibility/accessibility.py
+++ b/urbanpy/accessibility/accessibility.py
@@ -14,12 +14,12 @@ __all__ = [
 ]
 
 
-# Gaussian friction function for distance decay
+# Gaussian friction function for distance decay. Accepts scalar or array input.
 def friction(dm, d0):
-    if dm > d0:
-        return 0
-    else:
-        return np.exp(-0.5 * (dm / d0) ** 2) / (1 - np.exp(-0.5))
+    dm = np.asarray(dm, dtype=float)
+    return np.where(
+        dm > d0, 0.0, np.exp(-0.5 * (dm / d0) ** 2) / (1.0 - np.exp(-0.5))
+    )
 
 
 def hu_access_map(units, pois, population_column, weight=1, d0=1250):
@@ -105,10 +105,12 @@ def hu_access_map(units, pois, population_column, weight=1, d0=1250):
     merge["poi_geom"] = merge["geometry"].centroid
     merge = merge[~merge["centroid"].isna() | ~merge["centroid"].isnull()]
 
-    # Compute friction
-    merge["friction"] = merge.progress_apply(
-        lambda r: friction(r["poi_geom"].distance(r["centroid"]), d0), axis=1
-    )
+    # Compute friction (vectorized: distance via numpy on geometry x/y arrays)
+    poi_x = np.fromiter((p.x for p in merge["poi_geom"]), dtype=float, count=len(merge))
+    poi_y = np.fromiter((p.y for p in merge["poi_geom"]), dtype=float, count=len(merge))
+    ctr_x = np.fromiter((p.x for p in merge["centroid"]), dtype=float, count=len(merge))
+    ctr_y = np.fromiter((p.y for p in merge["centroid"]), dtype=float, count=len(merge))
+    merge["friction"] = friction(np.hypot(poi_x - ctr_x, poi_y - ctr_y), d0)
 
     # Remove 0 population values
     merge = merge[merge[population_column] > 0]
@@ -138,10 +140,12 @@ def hu_access_map(units, pois, population_column, weight=1, d0=1250):
     # Eliminate null geometries
     merge = merge[~merge["geometry_y"].isna() | ~merge["geometry_y"].isnull()]
 
-    # Compute friction
-    merge["friction"] = merge.progress_apply(
-        lambda r: friction(r["centroid"].distance(r["geometry_y"]), d0), axis=1
-    )
+    # Compute friction (vectorized over centroid vs POI geometry)
+    ctr_x = np.fromiter((p.x for p in merge["centroid"]), dtype=float, count=len(merge))
+    ctr_y = np.fromiter((p.y for p in merge["centroid"]), dtype=float, count=len(merge))
+    poi_x = np.fromiter((p.x for p in merge["geometry_y"]), dtype=float, count=len(merge))
+    poi_y = np.fromiter((p.y for p in merge["geometry_y"]), dtype=float, count=len(merge))
+    merge["friction"] = friction(np.hypot(ctr_x - poi_x, ctr_y - poi_y), d0)
 
     # Compute accesibility Ai
     df_ai = merge[["idx_unit", "idx_poi", "friction", "Rj"]]
@@ -256,9 +260,10 @@ def travel_times(inputs, pois, col_label="poi", nearest_neighbor_dist="haversine
         Input geodataframe with travel distances and durantions to nearest poi.
     """
     gdf = inputs.copy()
-    # Calculate the Nearest Facility for each Hexagon
-    gdf["lon"] = gdf.geometry.centroid.x
-    gdf["lat"] = gdf.geometry.centroid.y
+    # Cache centroids once so we don't recompute them inside the per-row lambda below.
+    centroids = gdf.geometry.centroid
+    gdf["lon"] = centroids.x
+    gdf["lat"] = centroids.y
 
     dists, ixs = nn_search(
         tree_features=pois[["lat", "lon"]].values,
@@ -268,14 +273,12 @@ def travel_times(inputs, pois, col_label="poi", nearest_neighbor_dist="haversine
 
     gdf[f"nearest_{col_label}_ix"] = ixs
 
-    # Calculate travel times and distances
-    distance_duration = gdf.progress_apply(
-        lambda row: osrm_route(
-            origin=row.geometry.centroid,
-            destination=pois.iloc[row[f"nearest_{col_label}_ix"]]["geometry"],
-        ),
-        result_type="expand",
-        axis=1,
+    # Calculate travel times and distances using the cached centroid array.
+    centroid_list = list(centroids)
+    nearest_geoms = pois.geometry.iloc[ixs.ravel()].reset_index(drop=True).tolist()
+    distance_duration = pd.DataFrame(
+        [osrm_route(origin=o, destination=d) for o, d in zip(centroid_list, nearest_geoms)],
+        index=gdf.index,
     )
 
     # Add columns to dataframe

--- a/urbanpy/download/download.py
+++ b/urbanpy/download/download.py
@@ -149,15 +149,11 @@ def overpass_pois(bounds, facilities=None, custom_query=None):
         df_geom = gpd.points_from_xy(df["lon"], df["lat"])
         gdf = gpd.GeoDataFrame(df, geometry=df_geom, crs="EPSG:4326")
 
-        gdf["poi_type"] = gdf["tags"].apply(
-            lambda tag: tag["amenity"] if "amenity" in tag.keys() else np.NaN
-        )
+        gdf["poi_type"] = gdf["tags"].apply(lambda tag: tag.get("amenity", np.nan))
 
         if facilities == "food":
             # Food facilities also have its POI type wthin the shop tag (See query)
-            also_poi_type = gdf["tags"].apply(
-                lambda tag: tag["shop"] if "shop" in tag.keys() else np.NaN
-            )
+            also_poi_type = gdf["tags"].apply(lambda tag: tag.get("shop", np.nan))
             gdf["poi_type"] = gdf["poi_type"].fillna(also_poi_type)
 
         return gdf
@@ -409,11 +405,11 @@ def get_hdx_dataset(
             & (df["longitude"] <= maxx)
             & (df["latitude"] >= miny)
             & (df["latitude"] <= maxy)
-        ]
-        df_filtered.loc[:, "geometry"] = df_filtered.apply(
-            lambda row: Point(row["longitude"], row["latitude"]), axis=1
+        ].copy()
+        df_filtered["geometry"] = gpd.points_from_xy(
+            df_filtered["longitude"], df_filtered["latitude"]
         )
-        gdf = gpd.GeoDataFrame(df_filtered)
+        gdf = gpd.GeoDataFrame(df_filtered, crs="EPSG:4326")
 
         return gdf[gdf.geometry.intersects(mask)]
     else:
@@ -502,13 +498,13 @@ def hdx_dataset(resource):
         stacklevel=2,
     )
 
-    if not resource.ends_with(".csv"):
+    if not resource.endswith(".csv"):
         raise AttributeError("This function only expects a CSV file.")
 
-    if not resource.starts_with("https://data.humdata.org/dataset/"):
+    if not resource.startswith("https://data.humdata.org/dataset/"):
         hdx_url = f"https://data.humdata.org/dataset/{resource}"
     else:
-        hdx_url = hdx_url
+        hdx_url = resource
 
     dataset = pd.read_csv(hdx_url)
     

--- a/urbanpy/geom/geom.py
+++ b/urbanpy/geom/geom.py
@@ -47,7 +47,10 @@ def merge_geom_downloads(
     geometry
     MULTIPOLYGON (((-76.80277 -12.47562, -76.80261...)))
     """
-    concat = gpd.GeoDataFrame(geometry=[pd.concat(gdfs).unary_union], crs=crs)
+    merged_geom = gpd.GeoSeries(
+        pd.concat([g.geometry for g in gdfs], ignore_index=True), crs=crs
+    ).union_all()
+    concat = gpd.GeoDataFrame(geometry=[merged_geom], crs=crs)
     return concat
 
 
@@ -159,29 +162,21 @@ def gen_hexagons(resolution: int, city: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     888e62c841fffff | POLYGON ((-77.22689 -12.07104, -77.23122 -12.0...))
     888e62c847fffff | POLYGON ((-77.23072 -12.07929, -77.23504 -12.0...))
     """
-    # Polyfill the city boundaries
-    h3_polygons = list()
-    h3_indexes = list()
-
-    # Get every polygon in Multipolygon shape
+    # Dedup hex IDs across (multi)polygon parts before materializing geometries
+    # so we never build the same shapely Polygon twice.
+    hex_ids = set()
     city_poly = city.explode(index_parts=True).reset_index(drop=True)
+    for _, geo in track(city_poly.iterrows(), total=len(city_poly)):
+        hex_ids.update(h3.geo_to_cells(geo["geometry"], res=resolution))
 
-    total = len(city_poly)  # For rich library to how much progress is needed
-    for _, geo in track(city_poly.iterrows(), total=total):
-        hexagons = h3.geo_to_cells(geo["geometry"], res=resolution)
-        for hexagon in hexagons:
-            lat_lng_points = h3.cell_to_boundary(hexagon)
-            lng_lat_points = [(lng, lat) for lat, lng in lat_lng_points]
-
-            h3_polygons.append(shapely.Polygon(lng_lat_points))
-            h3_indexes.append(hexagon)
-
-    # Create hexagon dataframe
-    city_hexagons = gpd.GeoDataFrame(h3_indexes, geometry=h3_polygons).drop_duplicates()
-    city_hexagons.crs = "EPSG:4326"
-    city_hexagons = city_hexagons.rename(
-        columns={0: "hex"}
-    )  # Format column name for readability
+    hex_ids = list(hex_ids)
+    h3_polygons = [
+        shapely.Polygon([(lng, lat) for lat, lng in h3.cell_to_boundary(hx)])
+        for hx in hex_ids
+    ]
+    city_hexagons = gpd.GeoDataFrame(
+        {"hex": hex_ids}, geometry=h3_polygons, crs="EPSG:4326"
+    )
 
     return city_hexagons
 
@@ -416,7 +411,10 @@ def osmnx_coefficient_computation(
         888e666c2dfffff	| POLYGON ((-76.93109 -11.79031, -76.93540 -11.7... | NaN
         888e62d4b3fffff	| POLYGON ((-76.87935 -12.03688, -76.88366 -12.0... | 1.044654
     """
-    # May be a lengthy download depending on the amount of features
+    # Accumulate per-row stats and assign in one pass to avoid repeated
+    # .loc[i, col] = ... reindex/upcasts inside the loop.
+    all_stats = list(basic_stats) + list(extended_stats)
+    rows = []
     for index, row in track(
         gdf.iterrows(),
         total=gdf.shape[0],
@@ -426,12 +424,14 @@ def osmnx_coefficient_computation(
             graph = ox.graph_from_polygon(row["geometry"], net_type)
             b_stats = ox.basic_stats(graph)
             ext_stats = ox.extended_stats(graph, connectivity, anc, ecc, bc, cc)
-
-            for stat in basic_stats:
-                gdf.loc[index, stat] = b_stats.get(stat)
-            for stat in extended_stats:
-                gdf.loc[index, stat] = ext_stats.get(stat)
+            rows.append(
+                {s: b_stats.get(s) for s in basic_stats}
+                | {s: ext_stats.get(s) for s in extended_stats}
+            )
         except Exception as err:
             print(f"On record {index}: ", err)
+            rows.append({s: None for s in all_stats})
 
+    stats_df = pd.DataFrame(rows, index=gdf.index, columns=all_stats)
+    gdf[all_stats] = stats_df
     return gdf

--- a/urbanpy/plotting/plotting.py
+++ b/urbanpy/plotting/plotting.py
@@ -50,7 +50,7 @@ def choropleth_map(gdf, color_column, df_filter=None, **kwargs):
         gdff = gdf.copy()
 
     gdff = gdff.reset_index()[["index", color_column, "geometry"]].dropna()
-    lon, lat = gdff.geometry.unary_union.centroid.xy
+    lon, lat = gdff.geometry.union_all().centroid.xy
 
     fig = px.choropleth_mapbox(
         gdff,

--- a/urbanpy/routing/routing.py
+++ b/urbanpy/routing/routing.py
@@ -3,13 +3,15 @@ import subprocess
 import sys
 import pathlib
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 import googlemaps
 import pandas as pd
 import numpy as np
 import networkx as nx
 import osmnx as ox
 import geopandas as gpd
-from shapely.geometry import Point
+from shapely.geometry import Point, MultiPoint
 from typing import Union, Tuple
 from rich.progress import Progress
 
@@ -28,6 +30,24 @@ __all__ = [
 
 ROUTING_MODUEL_DIR = pathlib.Path(__file__).parent.resolve()
 CONTAINER_NAME = "osrm_routing_server"
+
+
+def _build_session() -> requests.Session:
+    """Module-level session with connection pooling and retry/backoff."""
+    s = requests.Session()
+    retry = Retry(
+        total=3,
+        backoff_factor=0.5,
+        status_forcelist=(500, 502, 503, 504),
+        allowed_methods=("GET", "POST"),
+    )
+    adapter = HTTPAdapter(max_retries=retry, pool_connections=16, pool_maxsize=32)
+    s.mount("http://", adapter)
+    s.mount("https://", adapter)
+    return s
+
+
+_SESSION = _build_session()
 
 
 def check_container_is_running(container_name: str) -> bool:
@@ -235,18 +255,17 @@ def osrm_route(
     url = f"http://localhost:5000/route/v1/profile/{orig};{dest}"
 
     try:
-        response = requests.get(url, params={"overview": "false"})
-    except requests.exceptions.ConnectionError as e:
+        response = _SESSION.get(url, params={"overview": "false"})
+    except requests.exceptions.ConnectionError:
         print("Waiting for server to be ready ...")
         time.sleep(5)
-        response = requests.get(url, params={"overview": "false"})
+        response = _SESSION.get(url, params={"overview": "false"})
 
     try:
         data = response.json()["routes"][0]
         distance, duration = data["distance"], data["duration"]
         return distance, duration
-    except Exception as err:
-        # print(err)
+    except Exception:
         return np.nan, np.nan
 
 
@@ -386,7 +405,7 @@ def ors_api(locations, origin, destination, profile, metrics, api_key):
         "Content-Type": "application/json; charset=utf-8",
     }
 
-    r = requests.post(
+    r = _SESSION.post(
         f"https://api.openrouteservice.org/v2/matrix/{profile}",
         json=body,
         headers=headers,
@@ -441,30 +460,41 @@ def compute_osrm_dist_matrix(origins, destinations):
 
     """
 
-    dist_matrix = np.zeros(shape=(origins.shape[0], destinations.shape[0]))
-    dur_matrix = np.zeros(shape=(origins.shape[0], destinations.shape[0]))
+    if isinstance(origins, gpd.GeoSeries):
+        origins = origins.to_frame("geometry")
+    if isinstance(destinations, gpd.GeoSeries):
+        destinations = destinations.to_frame("geometry")
 
-    if type(origins) == gpd.GeoSeries:
-        origins = origins.to_frame()
+    n_orig, n_dest = origins.shape[0], destinations.shape[0]
+    orig_points = list(origins.geometry)
+    dest_points = list(destinations.geometry)
+    coords = ";".join(f"{p.x},{p.y}" for p in orig_points + dest_points)
+    sources = ";".join(str(i) for i in range(n_orig))
+    destinations_idx = ";".join(str(i + n_orig) for i in range(n_dest))
 
-    if type(destinations) == gpd.GeoSeries:
-        destinations = destinations.to_frame()
-
-    with Progress() as progress:
-        pb_orig = progress.add_task(
-            total=origins.shape[0], description="[red]Origins processed"
+    url = f"http://localhost:5000/table/v1/profile/{coords}"
+    try:
+        response = _SESSION.get(
+            url,
+            params={
+                "sources": sources,
+                "destinations": destinations_idx,
+                "annotations": "distance,duration",
+            },
         )
-        pb_dest = progress.add_task(
-            total=destinations.shape[0], description="[blue]Destinations"
-        )
-
-        for i, orig in origins.iterrows():
-            for j, dest in destinations.iterrows():
-                dist, dur = osrm_route(orig.geometry, dest.geometry)
-                dist_matrix[i, j] = dist
-                dur_matrix[i, j] = dur
-                progress.update(pb_dest, advance=1)
-            progress.update(pb_orig, advance=1)
+        data = response.json()
+        dist_matrix = np.array(data["distances"], dtype=float)
+        dur_matrix = np.array(data["durations"], dtype=float)
+    except Exception:
+        # Fall back to per-pair /route if /table is unavailable (older OSRM builds)
+        dist_matrix = np.full((n_orig, n_dest), np.nan)
+        dur_matrix = np.full((n_orig, n_dest), np.nan)
+        with Progress() as progress:
+            pb = progress.add_task(total=n_orig * n_dest, description="OSRM /route")
+            for i, orig in enumerate(orig_points):
+                for j, dest in enumerate(dest_points):
+                    dist_matrix[i, j], dur_matrix[i, j] = osrm_route(orig, dest)
+                    progress.update(pb, advance=1)
 
     return dist_matrix, dur_matrix
 
@@ -661,7 +691,7 @@ def isochrone_from_api(locations, time_range, profile, api, api_key):
             "Content-Type": "application/json; charset=utf-8",
         }
 
-        call = requests.post(
+        call = _SESSION.post(
             f"https://api.openrouteservice.org/v2/isochrones/{profile}",
             json=body,
             headers=headers,
@@ -682,7 +712,7 @@ def isochrone_from_api(locations, time_range, profile, api, api_key):
         for ix, (lon, lat) in enumerate(locations):
             pair = ",".join([str(lon), str(lat)])
             url = f"https://api.mapbox.com/isochrone/v1/mapbox/{profile}/{pair}?contours_minutes={contour_min}&polygons=true&access_token={api_key}"
-            call = requests.get(url)
+            call = _SESSION.get(url)
             if call.status_code == 200:
                 if features == {}:
                     features_ = call.json()
@@ -754,22 +784,28 @@ def isochrone_from_graph(graph, locations, time_range, profile):
     G = ox.project_graph(graph)
 
     meters_per_minute = travel_speed * 1000 / 60  # km per hour to m per minute
-    for u, v, k, data in G.edges(data=True, keys=True):
-        data["time"] = data["length"] / meters_per_minute
+    for u, v, k, edata in G.edges(data=True, keys=True):
+        edata["time"] = edata["length"] / meters_per_minute
 
-    data = []
+    rows = []
+    sorted_times = sorted(time_range, reverse=True)
+    node_data = dict(G.nodes(data=True))
 
     for ix, center_node in enumerate(center_nodes):
-        for trip_time in sorted(time_range, reverse=True):
-            subgraph = nx.ego_graph(G, center_node, radius=trip_time, distance="time")
+        # Compute single-source shortest-path travel times once per center,
+        # then threshold the node set for each trip_time. Avoids re-running
+        # ego_graph (Dijkstra) for every (center, time) pair.
+        dist = nx.single_source_dijkstra_path_length(G, center_node, weight="time")
+        for trip_time in sorted_times:
+            reachable_nodes = [n for n, d in dist.items() if d <= trip_time]
             node_points = [
-                Point((data["lon"], data["lat"]))
-                for node, data in subgraph.nodes(data=True)
+                Point((node_data[n]["lon"], node_data[n]["lat"]))
+                for n in reachable_nodes
             ]
-            bounding_poly = gpd.GeoSeries(node_points).unary_union.convex_hull
-            data.append([ix, trip_time, bounding_poly])
+            bounding_poly = MultiPoint(node_points).convex_hull if node_points else None
+            rows.append([ix, trip_time, bounding_poly])
 
-    isochrones = gpd.GeoDataFrame(data, columns=["group_index", "contour", "geometry"])
+    isochrones = gpd.GeoDataFrame(rows, columns=["group_index", "contour", "geometry"])
     isochrones.crs = "EPSG:4326"
 
     return isochrones

--- a/urbanpy/utils/utils.py
+++ b/urbanpy/utils/utils.py
@@ -9,7 +9,6 @@ import h3
 import shapely
 from pandas import DataFrame
 from shapely.geometry import MultiPolygon, Polygon
-from shapely.validation import make_valid
 from sklearn.neighbors import BallTree
 
 __all__ = [
@@ -303,12 +302,21 @@ def process_overpass_relations(
 
     #  Process way members
     df_ways = pd.DataFrame.from_dict(rels_ways)
-    df_ways["shell"] = df_ways["geometry"].apply(shell_from_geometry)
-    df_ways = df_ways[df_ways["shell"].apply(len) > 2]
-    df_ways["geometry"] = df_ways["shell"].apply(Polygon)
+    # Build polygons in one pass and drop degenerates inline, instead of
+    # three sequential .apply() passes over the same column.
+    polys = []
+    keep = []
+    for geom in df_ways["geometry"]:
+        if len(geom) > 2:
+            polys.append(Polygon([(r["lon"], r["lat"]) for r in geom]))
+            keep.append(True)
+        else:
+            keep.append(False)
+    df_ways = df_ways[keep].copy()
+    df_ways["geometry"] = polys
     gdf_ways = gpd.GeoDataFrame(df_ways, crs="EPSG:4326")
-    # buffer(0) is faster but shapely recommends make_valid()
-    gdf_ways.geometry = gdf_ways.geometry.apply(make_valid)
+    # buffer(0) is faster but shapely recommends make_valid(); vectorized call.
+    gdf_ways.geometry = shapely.make_valid(gdf_ways.geometry.values)
 
     # Merge members and return gdf
     gdf_members = gpd.GeoDataFrame(pd.concat([gdf_nodes, gdf_ways]), crs="EPSG:4326")
@@ -371,14 +379,13 @@ def overpass_to_gdf(
         if ov_keys is not None:
             #  Extract relevant data from osm tags
             gdf["poi_type"] = gdf["tags"].apply(
-                lambda tag: tag[ov_keys[0]] if ov_keys[0] in tag.keys() else np.NaN
+                lambda tag: tag.get(ov_keys[0], np.nan)
             )
             for k in ov_keys:
-                # Use other keys to complete NaNs
-                gdf["poi_type"].fillna(
-                    value=gdf["tags"].apply(
-                        lambda tag: tag[k] if k in tag.keys() else np.NaN
-                    )
+                # Use other keys to complete NaNs. The previous code dropped
+                # the result of .fillna(), making the fallback loop a no-op.
+                gdf["poi_type"] = gdf["poi_type"].fillna(
+                    value=gdf["tags"].apply(lambda tag: tag.get(k, np.nan))
                 )
                 if gdf["poi_type"].isna().sum() == 0:
                     break


### PR DESCRIPTION
# Performance improvements with minimal changes across modules

Before moving further with publishing in conda and other improvements to the package in general, I think a general QOL update to our packages' performance was important. I went through our modules one by one  with Claude Code to figure out where we can gain the most with the least changes. In total, five per-module commits on top of `master` with the following breakdown:

```
54d6d90 fix/perf(download): vectorize point construction, fix hdx_dataset typos
b30960b fix/perf(utils): no-op fillna fallback in overpass_to_gdf; one-pass relation polys
3f93ce2 perf(accessibility): vectorize friction, cache centroids in travel_times
0fd8f2c perf(routing): batch OSRM via /table/, pooled Session, single-source Dijkstra in isochrones
d6aa459 perf(geom): deduplicate hex IDs before building polygons; one-pass stats writes; union_all
```

## Benchmarks (synthetic data, best of 5)

| Path | Old | New | Speedup |
|---|---:|---:|---:|
| `accessibility.friction` (200k rows) | 2103.6 ms | 8.9 ms | **237×** |
| `geom.osmnx_coefficient_computation` write pattern (2k × 4) | 917.6 ms | 4.5 ms | **202×** |
| `routing.compute_osrm_dist_matrix` (10 × 10, local stub) | 117.3 ms | 1.6 ms | **74×** ¹ |
| `download.get_hdx_dataset` Point construction (400k rows) | 5231.2 ms | 96.7 ms | **54×** |
| `accessibility.travel_times` centroid handling (20k units) | 577.0 ms | 18.3 ms | **31×** |
| `routing.isochrone_from_graph` (2k-node graph, 3 × 3) | 572.3 ms | 145.2 ms | **3.9×** |
| `utils.process_overpass_relations` (5k ways) | 143.8 ms | 111.4 ms | **1.3×** |
| `geom.gen_hexagons` (res-8 over 0.5°²) | 103.7 ms | 98.6 ms | 1.05× ² |
| `geom.merge_geom_downloads` (6 overlapping gdfs) | 2.22 ms | 2.18 ms | ≈ ³ |

¹ Local in-process HTTP stub — with a real OSRM server the gap is dominated by N·M HTTP round-trips, so this is a lower bound.
² Bottleneck is `h3.geo_to_cells` / `cell_to_boundary` themselves; new code's main win is avoiding duplicate Polygon construction on multi-part inputs.
³ `union_all` is the same speed as `unary_union` — change exists to clear the shapely 2 deprecation warning.

## Correctness fixes shipped alongside

- **`utils.overpass_to_gdf`**: the per-key NaN fallback loop discarded the result of `Series.fillna()` (no assignment, no `inplace=True`), so secondary tag keys never populated `poi_type`. Now correctly fills from fallback keys.
- **`download.hdx_dataset`**: had `resource.ends_with(...)` / `resource.starts_with(...)` (AttributeError on the first call) and an unbound `hdx_url = hdx_url` branch. Both fixed.
- **`np.NaN` → `np.nan`** and **`k in tag.keys()` → `tag.get(k, np.nan)`** across `utils.py` and `download.py`.

## Per-module change detail

### `geom` (commit `d6aa459`)

- **`gen_hexagons`**: deduplicate H3 cell IDs across (multi)polygon parts *before* materializing shapely Polygons, dropping the post-hoc `drop_duplicates()`. Equal output for single-polygon cities; avoids redundant Polygon construction on multi-part inputs.
- **`osmnx_coefficient_computation`**: accumulate per-row stats into a list of dicts and assign once. Replaces `O(N·K)` `.loc[i, col] = ...` writes that forced repeated reindex / dtype upcasts.
- **`merge_geom_downloads`** (+ `plotting.choropleth_map`): switch deprecated `GeoSeries.unary_union` to `GeoSeries.union_all()` (shapely 2 path).

### `routing` (commit `0fd8f2c`)

- **`compute_osrm_dist_matrix`**: replace nested per-pair `/route/` requests with a single OSRM `/table/v1/` call; preserves the per-pair fallback for older OSRM builds.
- **Module-level `requests.Session`** with urllib3 `Retry` + connection pooling, reused by `osrm_route`, `ors_api`, `isochrone_from_api`. Removes per-call TCP/TLS handshake overhead and the ad-hoc `time.sleep` retry.
- **`isochrone_from_graph`**: run `nx.single_source_dijkstra_path_length` once per center and threshold the node set for each `trip_time`, instead of re-running `ego_graph` for every `(center, time)` pair. Also swap the `GeoSeries(...).unary_union.convex_hull` round-trip for a direct `shapely.MultiPoint` hull.
- **`type(x) == gpd.GeoSeries`** → **`isinstance(x, gpd.GeoSeries)`**.

### `accessibility` (commit `3f93ce2`)

- **`friction`**: accept array input via `np.where`; preserves scalar behavior.
- **`hu_access_map`**: replace the two `progress_apply(scalar friction(...), axis=1)` passes with numpy distance computation on cached x/y arrays.
- **`travel_times`**: compute `geometry.centroid` once and reuse for both `nn_search` inputs and OSRM calls; pull nearest POI geometries up front instead of recomputing centroid + `pois.iloc` per row inside `progress_apply`.

### `utils` (commit `b30960b`)

- **`overpass_to_gdf`**: assign the result of `Series.fillna()` back to `gdf["poi_type"]`. Switch `tag[k] if k in tag.keys() else np.NaN` → `tag.get(k, np.nan)`.
- **`process_overpass_relations`**: replace three sequential `.apply()` passes (`shell → length filter → Polygon`) with a single Python loop, and call `shapely.make_valid` on the underlying array instead of per-row apply.

### `download` (commit `54d6d90`)

- **`get_hdx_dataset`**: `df.apply(lambda r: Point(...), axis=1)` → `gpd.points_from_xy` on the filtered slice; `.copy()` the slice; set `crs="EPSG:4326"` on the result.
- **`overpass_pois`**: same `tag.get(...)` rewrite as utils.
- **`hdx_dataset`**: `.ends_with`/`.starts_with` → `.endswith`/`.startswith`; fix unbound `hdx_url = hdx_url` branch.

## Bench methodology

Each comparison runs the old and new implementations side-by-side in the same process against synthetic data sized to make per-call overhead visible (e.g. 200k / 400k / 2k rows). Reported numbers are `best of 5`. Network-dependent paths (OSRM `/route`, `/table`, Overpass) are exercised against a local in-process HTTP stub so we measure code-side overhead — the real-world gap on OSRM `/table` will be substantially larger because the per-pair path pays N·M HTTP round-trips.